### PR TITLE
feat: Implement multi-store support with Store and StoreConfig models

### DIFF
--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Auth\ResetPasswordRequest;
 use App\Http\Requests\Auth\UpdateProfileRequest;
 use App\Http\Traits\ApiResponseTrait;
 use App\Models\User;
+use App\Services\CurrentStore;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -78,7 +79,18 @@ class AuthController extends Controller
      */
     public function register(RegisterRequest $request): JsonResponse
     {
+        // Requiere tienda (tenant) para asociar al usuario
+        if (!CurrentStore::has()) {
+            return $this->errorResponse(
+                'STORE_REQUIRED',
+                "Debe especificar la tienda mediante el header 'X-Store-Id' (o 'Store-Id') para registrar usuarios.",
+                400
+            );
+        }
+
         $userData = $request->getUserData();
+        $userData['store_id'] = CurrentStore::id();
+
         $user = $this->createUser($userData);
         $token = $this->createAuthToken($user);
 

--- a/app/Http/Controllers/Api/V1/StoreController.php
+++ b/app/Http/Controllers/Api/V1/StoreController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Traits\ApiResponseTrait;
+use Illuminate\Http\Request;
+use App\Models\Store;
+use App\Http\Resources\StoreResource;
+use Illuminate\Support\Str;
+use App\Http\Requests\Store\StoreCreateRequest;
+use App\Http\Requests\Store\StoreUpdateRequest;
+
+/**
+ * @see \\App\\OpenApi\\Documentation\\StoreEndpoints
+ */
+class StoreController extends Controller
+{
+    use ApiResponseTrait;
+
+    public function index(Request $request)
+    {
+        $stores = Store::query();
+        if ($request->has('include') && in_array('config', explode(',', $request->input('include')))) {
+            $stores->with('config');
+        }
+        return $this->successResponse(StoreResource::collection($stores->get()));
+    }
+
+    public function store(StoreCreateRequest $request)
+    {
+        $data = $request->validated();
+        $store = Store::create([
+            'id' => Str::uuid(),
+            'name' => $data['name'],
+        ]);
+        if (isset($data['config'])) {
+            $configData = $data['config'];
+            $store->config()->create([
+                'products' => $configData['products'] ?? true,
+                'categories' => $configData['categories'] ?? true,
+                'cupons' => $configData['cupons'] ?? false,
+                'gifcards' => $configData['gifcards'] ?? false,
+                'wishlist' => $configData['wishlist'] ?? false,
+                'reviews' => $configData['reviews'] ?? false,
+                'notifications_emails' => $configData['notifications']['emails'] ?? true,
+                'notifications_telegram' => $configData['notifications']['telegram'] ?? false,
+            ]);
+        }
+        $store->load('config');
+        return $this->successResponse(new StoreResource($store), 201);
+    }
+
+    public function show(Request $request, $id)
+    {
+        $store = Store::query();
+        if ($request->has('include') && in_array('config', explode(',', $request->input('include')))) {
+            $store->with('config');
+        }
+        $store = $store->findOrFail($id);
+        return $this->successResponse(new StoreResource($store));
+    }
+
+    public function update(StoreUpdateRequest $request, $id)
+    {
+        $data = $request->validated();
+        $store = Store::findOrFail($id);
+        if (isset($data['name'])) {
+            $store->name = $data['name'];
+            $store->save();
+        }
+        if (isset($data['config'])) {
+            $configData = $data['config'];
+            $config = $store->config;
+            if ($config) {
+                $config->update([
+                    'products' => $configData['products'] ?? $config->products,
+                    'categories' => $configData['categories'] ?? $config->categories,
+                    'cupons' => $configData['cupons'] ?? $config->cupons,
+                    'gifcards' => $configData['gifcards'] ?? $config->gifcards,
+                    'wishlist' => $configData['wishlist'] ?? $config->wishlist,
+                    'reviews' => $configData['reviews'] ?? $config->reviews,
+                    'notifications_emails' => $configData['notifications']['emails'] ?? $config->notifications_emails,
+                    'notifications_telegram' => $configData['notifications']['telegram'] ?? $config->notifications_telegram,
+                ]);
+            } else {
+                $store->config()->create([
+                    'products' => $configData['products'] ?? true,
+                    'categories' => $configData['categories'] ?? true,
+                    'cupons' => $configData['cupons'] ?? false,
+                    'gifcards' => $configData['gifcards'] ?? false,
+                    'wishlist' => $configData['wishlist'] ?? false,
+                    'reviews' => $configData['reviews'] ?? false,
+                    'notifications_emails' => $configData['notifications']['emails'] ?? true,
+                    'notifications_telegram' => $configData['notifications']['telegram'] ?? false,
+                ]);
+            }
+        }
+        $store->load('config');
+        return $this->successResponse(new StoreResource($store));
+    }
+
+    public function destroy($id)
+    {
+        $store = Store::findOrFail($id);
+        $store->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -31,6 +31,14 @@ use OpenApi\Attributes as OA;
  *     name="Authorization",
  *     description="Token de autenticación Sanctum. Formato: 'Bearer {token}'"
  * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="tenant",
+ *     type="apiKey",
+ *     in="header",
+ *     name="X-Store-Id",
+ *     description="Identificador de la tienda (tenant). Alternativamente puede usarse 'Store-Id'"
+ * )
  * 
  * @OA\Tag(
  *     name="Authentication",

--- a/app/Http/Controllers/ProductsController.php
+++ b/app/Http/Controllers/ProductsController.php
@@ -8,6 +8,7 @@ use App\Models\Product;
 use App\Http\Resources\ProductResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\JsonResponse;
+use App\Services\CurrentStore;
 
 
 class ProductsController extends Controller
@@ -15,9 +16,12 @@ class ProductsController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index():JsonResource
+    public function index(): JsonResource
     {
-        return ProductResource::collection(Product::all());
+        // El StoreScope del trait BelongsToStore ya filtra por tienda automáticamente.
+        // Paginamos para evitar respuestas enormes.
+        $products = Product::query()->paginate(15);
+        return ProductResource::collection($products);
     }
 
 
@@ -26,38 +30,44 @@ class ProductsController extends Controller
      */
     public function store(ProductsRequest $request): JsonResponse
     {
-        
-        $product = Product::create($request->all());
+        $data = $request->validated();
+        // Asegurar que el producto quede asociado a la tienda del header
+        unset($data['store_id']);
+        $data['store_id'] = CurrentStore::id();
+
+        $product = Product::create($data);
 
         return response()->json([
             'message' => 'Product created successfully',
             'data' => new ProductResource($product)
         ], 201);
-
-
     }
-    
+
 
     /**
      * Display the specified resource.
      */
     public function show(string $id): JsonResponse
     {
-        
+
         $product = Product::findOrFail($id);
-        
-    return response()->json([
-        'data' => new ProductResource($product)
-    ]);
+
+        return response()->json([
+            'data' => new ProductResource($product)
+        ]);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(ProductsRequest $request, string $id)    
+    public function update(ProductsRequest $request, string $id)
     {
         $product = Product::findOrFail($id);
-        $product->update($request->all());
+        $data = $request->validated();
+        // Evitar cambios de tienda por el body
+        unset($data['store_id']);
+
+        $product->update($data);
 
         return response()->json([
             'message' => 'Product updated successfully',

--- a/app/Http/Middleware/RequireStore.php
+++ b/app/Http/Middleware/RequireStore.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\CurrentStore;
+use Closure;
+use Illuminate\Http\Request;
+
+class RequireStore
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!CurrentStore::has()) {
+            return response()->json([
+                'success' => false,
+                'error' => [
+                    'code' => 'STORE_REQUIRED',
+                    'message' => "Debe especificar la tienda mediante el header 'X-Store-Id' (o 'Store-Id')",
+                ]
+            ], 400);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ResolveStore.php
+++ b/app/Http/Middleware/ResolveStore.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Store;
+use App\Services\CurrentStore;
+use Closure;
+use Illuminate\Http\Request;
+
+class ResolveStore
+{
+    public function handle(Request $request, Closure $next)
+    {
+        // Soporta header 'X-Store-Id' o 'Store-Id'
+        $storeId = $request->header('X-Store-Id') ?? $request->header('Store-Id');
+
+        if ($storeId) {
+            $store = Store::query()->find($storeId);
+            if ($store) {
+                CurrentStore::set($store);
+            }
+        }
+
+        // También permitir resolver por subdominio futuro o query param 'store_id'
+        if (!CurrentStore::has() && $request->query('store_id')) {
+            $store = Store::query()->find($request->query('store_id'));
+            if ($store) {
+                CurrentStore::set($store);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Auth;
 
 use App\Http\Requests\Traits\HandlesValidationErrors;
+use App\Services\CurrentStore;
 use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -55,6 +56,8 @@ class RegisterRequest extends FormRequest
                     ->symbols()
                     ->uncompromised(),
             ],
+            // Opcionalmente permitir store_id en el body, pero se sobrescribirá por el header si existe
+            'store_id' => ['nullable', 'uuid'],
         ];
     }
 
@@ -91,6 +94,13 @@ class RegisterRequest extends FormRequest
 
         // Set default role if not provided
         $data['role'] = $this->input('role', User::ROLE_CUSTOMER);
+
+        // Si hay tienda actual, usarla; si no, usar store_id si vino en el body
+        if (CurrentStore::has()) {
+            $data['store_id'] = CurrentStore::id();
+        } elseif ($this->filled('store_id')) {
+            $data['store_id'] = $this->input('store_id');
+        }
 
         return $data;
     }

--- a/app/Http/Requests/ProductsRequest.php
+++ b/app/Http/Requests/ProductsRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests;
 
 use App\Http\Requests\Traits\HandlesValidationErrors;
+use App\Services\CurrentStore;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class ProductsRequest extends FormRequest
 {
@@ -23,19 +25,47 @@ class ProductsRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        $isCreate = $this->isMethod('post');
+        $productId = $this->route('product');
+        $storeId = CurrentStore::id();
 
-            'name' => 'required|string|max:255',
-            'slug' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'short_description' => 'nullable|string|max:500',
-            'price' => 'required|numeric|min:0',
-            'compare_price' => 'nullable|numeric|min:0',
-            'cost_price' => 'nullable|numeric|min:0',
-            'track_quantity' => 'required|integer|min:0',
-            'sku' => 'required|string|max:100',
-            'status' => 'required|in:active,inactive,out_of_stock',
-            'category_id' => 'nullable|exists:categories,id',
+        $rules = [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:255',
+                $isCreate
+                    ? Rule::unique('products', 'slug')
+                    : Rule::unique('products', 'slug')->ignore($productId)
+            ],
+            'description' => ['nullable', 'string'],
+            'short_description' => ['nullable', 'string', 'max:500'],
+            'price' => ['required', 'numeric', 'min:0'],
+            'compare_price' => ['nullable', 'numeric', 'min:0'],
+            'cost_price' => ['nullable', 'numeric', 'min:0'],
+            'track_quantity' => ['required', 'integer', 'min:0'],
+            'sku' => [
+                'required',
+                'string',
+                'max:100',
+                $isCreate
+                    ? Rule::unique('products', 'sku')
+                    : Rule::unique('products', 'sku')->ignore($productId)
+            ],
+            'status' => ['required', Rule::in(['active', 'inactive', 'out_of_stock'])],
         ];
+
+        // category_id requerido en creación; opcional en update, pero si viene debe existir en la misma tienda
+        $categoryExistsInStore = Rule::exists('categories', 'id')
+            ->where(fn($q) => $q->where('store_id', $storeId));
+
+        if ($isCreate) {
+            $rules['category_id'] = ['required', 'integer', $categoryExistsInStore];
+        } else {
+            $rules['category_id'] = ['nullable', 'integer', $categoryExistsInStore];
+        }
+
+        return $rules;
     }
 }

--- a/app/Http/Requests/Store/StoreCreateRequest.php
+++ b/app/Http/Requests/Store/StoreCreateRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Store;
+
+use App\Http\Requests\Traits\HandlesValidationErrors;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCreateRequest extends FormRequest
+{
+    use HandlesValidationErrors;
+
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|unique:store,name',
+            'config' => 'array',
+            'config.products' => 'boolean',
+            'config.categories' => 'boolean',
+            'config.cupons' => 'boolean',
+            'config.gifcards' => 'boolean',
+            'config.wishlist' => 'boolean',
+            'config.reviews' => 'boolean',
+            'config.notifications.emails' => 'boolean',
+            'config.notifications.telegram' => 'boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/Store/StoreUpdateRequest.php
+++ b/app/Http/Requests/Store/StoreUpdateRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Store;
+
+use App\Http\Requests\Traits\HandlesValidationErrors;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUpdateRequest extends FormRequest
+{
+    use HandlesValidationErrors;
+
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        $id = $this->route('id');
+        return [
+            'name' => 'sometimes|string|unique:store,name,' . $id . ',id',
+            'config' => 'array',
+            'config.products' => 'boolean',
+            'config.categories' => 'boolean',
+            'config.cupons' => 'boolean',
+            'config.gifcards' => 'boolean',
+            'config.wishlist' => 'boolean',
+            'config.reviews' => 'boolean',
+            'config.notifications.emails' => 'boolean',
+            'config.notifications.telegram' => 'boolean',
+        ];
+    }
+}

--- a/app/Http/Resources/StoreConfigResource.php
+++ b/app/Http/Resources/StoreConfigResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreConfigResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'store_id' => $this->store_id,
+            'products' => $this->products,
+            'categories' => $this->categories,
+            'cupons' => $this->cupons,
+            'gifcards' => $this->gifcards,
+            'wishlist' => $this->wishlist,
+            'reviews' => $this->reviews,
+            'notifications' => [
+                'emails' => $this->notifications_emails,
+                'telegram' => $this->notifications_telegram,
+            ],
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}
+

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request)
+    {
+        $data = [
+            'id' => $this->id,
+            'name' => $this->name,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+
+        // Only include config if requested
+        if ($request->has('include') && in_array('config', explode(',', $request->input('include')))) {
+            $data['config'] = new StoreConfigResource($this->config);
+        }
+
+        return $data;
+    }
+}
+

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -8,12 +8,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use App\Models\Traits\BelongsToStore;
 
 class Cart extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, BelongsToStore;
 
     protected $fillable = [
+        'store_id',
         'user_id',
         'session_id',
         'status',
@@ -60,6 +62,11 @@ class Cart extends Model
     public function items(): HasMany
     {
         return $this->hasMany(CartItem::class);
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class, 'store_id');
     }
 
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -7,10 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use App\Models\Traits\BelongsToStore;
 
 class Category extends Model
 {
-    use HasFactory;
+    use HasFactory, BelongsToStore;
 
     protected $hidden = [
         'created_at',
@@ -22,5 +23,10 @@ class Category extends Model
     public function products(): HasMany
     {
         return $this->hasMany(Product::class, 'category_id', 'id');
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class, 'store_id');
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -9,12 +9,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Carbon\Carbon;
+use App\Models\Traits\BelongsToStore;
 
 class Order extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, BelongsToStore;
 
     protected $fillable = [
+        'store_id',
         'order_number',
         'user_id',
         'status',
@@ -93,6 +95,11 @@ class Order extends Model
     public function items(): HasMany
     {
         return $this->hasMany(OrderItem::class);
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class, 'store_id');
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -7,11 +7,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Traits\BelongsToStore;
 
 class Product extends Model
 {
 
-    use HasFactory;
+    use HasFactory, BelongsToStore;
 
     protected $guarded = [];
 
@@ -29,6 +30,11 @@ class Product extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(Category::class);
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class, 'store_id');
     }
 
     public function images(): HasMany

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Store extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'store';
+    public $incrementing = false;
+    protected $keyType = 'string';
+    protected $fillable = [
+        'id',
+        'name',
+    ];
+
+    public function config()
+    {
+        return $this->hasOne(StoreConfig::class, 'store_id');
+    }
+}
+

--- a/app/Models/StoreConfig.php
+++ b/app/Models/StoreConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StoreConfig extends Model
+{
+    protected $table = 'store_configs';
+    protected $fillable = [
+        'store_id',
+        'products',
+        'categories',
+        'cupons',
+        'gifcards',
+        'wishlist',
+        'reviews',
+        'notifications_emails',
+        'notifications_telegram',
+    ];
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class, 'store_id');
+    }
+}
+

--- a/app/Models/Traits/BelongsToStore.php
+++ b/app/Models/Traits/BelongsToStore.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Services\CurrentStore;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Schema;
+
+class StoreScope implements Scope
+{
+    public function apply(Builder $builder, Model $model)
+    {
+        $storeId = CurrentStore::id();
+        if ($storeId && Schema::hasColumn($model->getTable(), 'store_id')) {
+            $builder->where($model->getTable() . '.store_id', $storeId);
+        }
+    }
+}
+
+trait BelongsToStore
+{
+    public static function bootBelongsToStore(): void
+    {
+        static::addGlobalScope(new StoreScope());
+
+        // En creación, si el modelo tiene columna store_id y hay tienda actual, asignarla
+        static::creating(function (Model $model) {
+            if (Schema::hasColumn($model->getTable(), 'store_id') && empty($model->getAttribute('store_id'))) {
+                $storeId = CurrentStore::id();
+                if ($storeId) {
+                    $model->setAttribute('store_id', $storeId);
+                }
+            }
+        });
+    }
+
+    public function scopeForCurrentStore(Builder $query): Builder
+    {
+        $storeId = CurrentStore::id();
+        return $storeId ? $query->where($this->getTable() . '.store_id', $storeId) : $query;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,7 @@ class User extends Authenticatable
         'status',
         'phone',
         'avatar',
+        'store_id',
     ];
 
     /**
@@ -176,5 +177,13 @@ class User extends Authenticatable
             self::STATUS_INACTIVE,
             self::STATUS_SUSPENDED,
         ];
+    }
+
+    /**
+     * Relación con Store (opcional)
+     */
+    public function store(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(Store::class, 'store_id');
     }
 }

--- a/app/OpenApi/Documentation/AuthEndpoints.php
+++ b/app/OpenApi/Documentation/AuthEndpoints.php
@@ -44,6 +44,9 @@ class AuthEndpoints
         path: "/api/v1/auth/register",
         summary: "Registrar nuevo usuario",
         description: "Registra un nuevo usuario en el sistema",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+        ],
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\JsonContent(ref: "#/components/schemas/RegisterRequest")

--- a/app/OpenApi/Documentation/CartEndpoints.php
+++ b/app/OpenApi/Documentation/CartEndpoints.php
@@ -17,6 +17,7 @@ class CartEndpoints
         description: "Obtiene el carrito actual del usuario autenticado o guest",
         tags: ["Cart"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "X-Session-ID",
                 description: "ID de sesión para usuarios guest",
@@ -50,6 +51,7 @@ class CartEndpoints
         ),
         tags: ["Cart"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "X-Session-ID",
                 description: "ID de sesión para usuarios guest",
@@ -88,6 +90,7 @@ class CartEndpoints
         ),
         tags: ["Cart"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "item",
                 description: "ID del item del carrito",
@@ -134,6 +137,7 @@ class CartEndpoints
         description: "Elimina un item específico del carrito",
         tags: ["Cart"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "item",
                 description: "ID del item del carrito",
@@ -175,6 +179,7 @@ class CartEndpoints
         description: "Elimina todos los items del carrito",
         tags: ["Cart"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "X-Session-ID",
                 description: "ID de sesión para usuarios guest",
@@ -208,6 +213,9 @@ class CartEndpoints
             content: new OA\JsonContent(ref: "#/components/schemas/MergeCartRequest")
         ),
         tags: ["Cart"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+        ],
         responses: [
             new OA\Response(
                 response: 200,

--- a/app/OpenApi/Documentation/OrderEndpoints.php
+++ b/app/OpenApi/Documentation/OrderEndpoints.php
@@ -18,6 +18,7 @@ class OrderEndpoints
         security: [["sanctum" => []]],
         tags: ["Orders"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "per_page",
                 description: "Número de elementos por página (máximo 50)",
@@ -88,6 +89,9 @@ class OrderEndpoints
             content: new OA\JsonContent(ref: "#/components/schemas/CreateOrderRequest")
         ),
         tags: ["Orders"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+        ],
         responses: [
             new OA\Response(
                 response: 201,
@@ -125,6 +129,7 @@ class OrderEndpoints
         security: [["sanctum" => []]],
         tags: ["Orders"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "orderNumber",
                 description: "Número del pedido",
@@ -169,6 +174,7 @@ class OrderEndpoints
         ),
         tags: ["Orders"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "order",
                 description: "ID del pedido",
@@ -224,6 +230,7 @@ class OrderEndpoints
         security: [["sanctum" => []], ["role" => ["admin"]]],
         tags: ["Orders - Admin"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "per_page",
                 description: "Número de elementos por página (máximo 100)",
@@ -300,6 +307,7 @@ class OrderEndpoints
         ),
         tags: ["Orders - Admin"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "order",
                 description: "ID del pedido",
@@ -350,6 +358,7 @@ class OrderEndpoints
         security: [["sanctum" => []], ["role" => ["admin"]]],
         tags: ["Orders - Admin"],
         parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
             new OA\Parameter(
                 name: "date_from",
                 description: "Fecha inicio para estadísticas (YYYY-MM-DD)",

--- a/app/OpenApi/Documentation/ProductsEndpoints.php
+++ b/app/OpenApi/Documentation/ProductsEndpoints.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Documentation;
+
+use OpenApi\Attributes as OA;
+
+/**
+ * Documentación de endpoints de productos
+ */
+class ProductsEndpoints
+{
+    #[OA\Get(
+        path: "/api/v1/products",
+        summary: "Listar productos",
+        description: "Lista paginada de productos del tenant actual",
+        tags: ["Products"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+            new OA\Parameter(name: "page", in: "query", required: false, schema: new OA\Schema(type: "integer", minimum: 1, example: 1)),
+            new OA\Parameter(name: "per_page", in: "query", required: false, schema: new OA\Schema(type: "integer", minimum: 1, maximum: 100, example: 15))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "Lista de productos"),
+        ]
+    )]
+    public function index() {}
+
+    #[OA\Get(
+        path: "/api/v1/products/{product}",
+        summary: "Obtener detalle de producto",
+        description: "Devuelve el detalle de un producto por ID",
+        tags: ["Products"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+            new OA\Parameter(
+                name: "product",
+                in: "path",
+                required: true,
+                schema: new OA\Schema(type: "string")
+            )
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "Detalle de producto"),
+            new OA\Response(response: 404, description: "No encontrado")
+        ]
+    )]
+    public function show() {}
+
+    #[OA\Post(
+        path: "/api/v1/products",
+        summary: "Crear producto",
+        description: "Crea un nuevo producto para el tenant actual",
+        tags: ["Products"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id")
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: "#/components/schemas/ProductCreateRequest")
+        ),
+        responses: [
+            new OA\Response(response: 201, description: "Producto creado"),
+            new OA\Response(response: 422, description: "Error de validación")
+        ]
+    )]
+    public function store() {}
+
+    #[OA\Put(
+        path: "/api/v1/products/{product}",
+        summary: "Actualizar producto",
+        description: "Actualiza un producto existente",
+        tags: ["Products"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+            new OA\Parameter(
+                name: "product",
+                in: "path",
+                required: true,
+                schema: new OA\Schema(type: "string")
+            )
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: "#/components/schemas/ProductUpdateRequest")
+        ),
+        responses: [
+            new OA\Response(response: 200, description: "Producto actualizado"),
+            new OA\Response(response: 404, description: "No encontrado"),
+            new OA\Response(response: 422, description: "Error de validación")
+        ]
+    )]
+    public function update() {}
+
+    #[OA\Delete(
+        path: "/api/v1/products/{product}",
+        summary: "Eliminar producto",
+        description: "Elimina (soft/hard según implementación) un producto",
+        tags: ["Products"],
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/X-Store-Id"),
+            new OA\Parameter(
+                name: "product",
+                in: "path",
+                required: true,
+                schema: new OA\Schema(type: "string")
+            )
+        ],
+        responses: [
+            new OA\Response(response: 204, description: "Producto eliminado"),
+            new OA\Response(response: 404, description: "No encontrado")
+        ]
+    )]
+    public function destroy() {}
+}

--- a/app/OpenApi/Documentation/StoreEndpoints.php
+++ b/app/OpenApi/Documentation/StoreEndpoints.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\OpenApi\Documentation;
+
+/**
+ * @see \App\Http\Controllers\Api\V1\StoreController
+ *
+ * @OA\Tag(
+ *     name="Store",
+ *     description="Store management"
+ * )
+ *
+ * @OA\Get(
+ *     path="/api/v1/store",
+ *     tags={"Store"},
+ *     summary="Get all stores",
+ *     @OA\Parameter(
+ *         name="include",
+ *         in="query",
+ *         description="Include related config",
+ *         required=false,
+ *         @OA\Schema(type="string", example="config")
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="List of stores",
+ *         @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/Store"))
+ *     )
+ * )
+ *
+ * @OA\Post(
+ *     path="/api/v1/store",
+ *     tags={"Store"},
+ *     summary="Create a new store with optional config",
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(ref="#/components/schemas/StoreCreateRequest")
+ *     ),
+ *     @OA\Response(
+ *         response=201,
+ *         description="Store created",
+ *         @OA\JsonContent(ref="#/components/schemas/Store")
+ *     )
+ * )
+ *
+ * @OA\Get(
+ *     path="/api/v1/store/{id}",
+ *     tags={"Store"},
+ *     summary="Get a store by ID",
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         @OA\Schema(type="string")
+ *     ),
+ *     @OA\Parameter(
+ *         name="include",
+ *         in="query",
+ *         description="Include related config",
+ *         required=false,
+ *         @OA\Schema(type="string", example="config")
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="Store details",
+ *         @OA\JsonContent(ref="#/components/schemas/Store")
+ *     ),
+ *     @OA\Response(response=404, description="Not found")
+ * )
+ *
+ * @OA\Put(
+ *     path="/api/v1/store/{id}",
+ *     tags={"Store"},
+ *     summary="Update a store and its config",
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         @OA\Schema(type="string")
+ *     ),
+ *     @OA\RequestBody(
+ *         required=true,
+ *         @OA\JsonContent(ref="#/components/schemas/StoreUpdateRequest")
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="Store updated",
+ *         @OA\JsonContent(ref="#/components/schemas/Store")
+ *     ),
+ *     @OA\Response(response=404, description="Not found")
+ * )
+ *
+ * @OA\Delete(
+ *     path="/api/v1/store/{id}",
+ *     tags={"Store"},
+ *     summary="Soft delete a store",
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         @OA\Schema(type="string")
+ *     ),
+ *     @OA\Response(
+ *         response=204,
+ *         description="Store deleted"
+ *     ),
+ *     @OA\Response(response=404, description="Not found")
+ * )
+ */
+class StoreEndpoints {}
+

--- a/app/OpenApi/Schemas/Product/ProductCreateRequestSchema.php
+++ b/app/OpenApi/Schemas/Product/ProductCreateRequestSchema.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas\Product;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: "ProductCreateRequest",
+    type: "object",
+    description: "Datos requeridos para crear un producto",
+    required: [
+        "name",
+        "slug",
+        "price",
+        "track_quantity",
+        "sku",
+        "status",
+        "category_id"
+    ],
+    properties: [
+        new OA\Property(property: "name", type: "string", maxLength: 255, example: "Camiseta básica unisex"),
+        new OA\Property(property: "slug", type: "string", maxLength: 255, example: "camiseta-basica-unisex"),
+        new OA\Property(property: "description", type: "string", nullable: true, example: "Camiseta de algodón 100% con corte clásico."),
+        new OA\Property(property: "short_description", type: "string", nullable: true, maxLength: 500, example: "Camiseta de algodón de alta calidad"),
+        new OA\Property(property: "price", type: "number", format: "float", minimum: 0, example: 19.99),
+        new OA\Property(property: "compare_price", type: "number", format: "float", minimum: 0, nullable: true, example: 24.99),
+        new OA\Property(property: "cost_price", type: "number", format: "float", minimum: 0, nullable: true, example: 9.50),
+        new OA\Property(property: "track_quantity", type: "integer", minimum: 0, example: 1),
+        new OA\Property(property: "sku", type: "string", maxLength: 100, example: "TSHIRT-UNISEX-001"),
+        new OA\Property(property: "status", type: "string", enum: ["active", "inactive", "out_of_stock"], example: "active"),
+        new OA\Property(property: "category_id", type: "integer", example: 1)
+    ]
+)]
+class ProductCreateRequestSchema {}

--- a/app/OpenApi/Schemas/Product/ProductUpdateRequestSchema.php
+++ b/app/OpenApi/Schemas/Product/ProductUpdateRequestSchema.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas\Product;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: "ProductUpdateRequest",
+    type: "object",
+    description: "Datos para actualizar un producto existente",
+    properties: [
+        new OA\Property(property: "name", type: "string", maxLength: 255, example: "Camiseta básica unisex"),
+        new OA\Property(property: "slug", type: "string", maxLength: 255, example: "camiseta-basica-unisex"),
+        new OA\Property(property: "description", type: "string", nullable: true, example: "Camiseta de algodón 100% con corte clásico."),
+        new OA\Property(property: "short_description", type: "string", nullable: true, maxLength: 500, example: "Camiseta de algodón de alta calidad"),
+        new OA\Property(property: "price", type: "number", format: "float", minimum: 0, example: 19.99),
+        new OA\Property(property: "compare_price", type: "number", format: "float", minimum: 0, nullable: true, example: 24.99),
+        new OA\Property(property: "cost_price", type: "number", format: "float", minimum: 0, nullable: true, example: 9.50),
+        new OA\Property(property: "track_quantity", type: "integer", minimum: 0, example: 1),
+        new OA\Property(property: "sku", type: "string", maxLength: 100, example: "TSHIRT-UNISEX-001"),
+        new OA\Property(property: "status", type: "string", enum: ["active", "inactive", "out_of_stock"], example: "active"),
+        new OA\Property(property: "category_id", type: "integer", nullable: true, example: 1)
+    ]
+)]
+class ProductUpdateRequestSchema {}

--- a/app/OpenApi/Schemas/StoreConfigSchema.php
+++ b/app/OpenApi/Schemas/StoreConfigSchema.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="StoreConfig",
+ *     type="object",
+ *     required={"products", "categories", "cupons", "gifcards", "wishlist", "reviews", "notifications"},
+ *     @OA\Property(property="id", type="string", example="b3b8c7e2-2231-4e5f-8a6b-123123123123"),
+ *     @OA\Property(property="store_id", type="string", format="uuid", example="b3b8c7e2-1c2d-4e5f-8a6b-123456789abc"),
+ *     @OA\Property(property="products", type="boolean", example=true),
+ *     @OA\Property(property="categories", type="boolean", example=true),
+ *     @OA\Property(property="cupons", type="boolean", example=false),
+ *     @OA\Property(property="gifcards", type="boolean", example=false),
+ *     @OA\Property(property="wishlist", type="boolean", example=false),
+ *     @OA\Property(property="reviews", type="boolean", example=false),
+ *     @OA\Property(
+ *         property="notifications",
+ *         type="object",
+ *         @OA\Property(property="emails", type="boolean", example=true),
+ *         @OA\Property(property="telegram", type="boolean", example=false)
+ *     ),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
+class StoreConfigSchema {}
+

--- a/app/OpenApi/Schemas/StoreCreateRequestSchema.php
+++ b/app/OpenApi/Schemas/StoreCreateRequestSchema.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="StoreCreateRequest",
+ *     type="object",
+ *     required={"name"},
+ *     @OA\Property(property="name", type="string", example="My Store"),
+ *     @OA\Property(
+ *         property="config",
+ *         type="object",
+ *         @OA\Property(property="products", type="boolean", example=true),
+ *         @OA\Property(property="categories", type="boolean", example=true),
+ *         @OA\Property(property="cupons", type="boolean", example=false),
+ *         @OA\Property(property="gifcards", type="boolean", example=false),
+ *         @OA\Property(property="wishlist", type="boolean", example=false),
+ *         @OA\Property(property="reviews", type="boolean", example=false),
+ *         @OA\Property(
+ *             property="notifications",
+ *             type="object",
+ *             @OA\Property(property="emails", type="boolean", example=true),
+ *             @OA\Property(property="telegram", type="boolean", example=false)
+ *         )
+ *     )
+ * )
+ */
+class StoreCreateRequestSchema {}
+

--- a/app/OpenApi/Schemas/StoreSchema.php
+++ b/app/OpenApi/Schemas/StoreSchema.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Store",
+ *     type="object",
+ *     required={"id", "name"},
+ *     @OA\Property(property="id", type="string", format="uuid", example="b3b8c7e2-1c2d-4e5f-8a6b-123456789abc"),
+ *     @OA\Property(property="name", type="string", example="My Store"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time"),
+ *     @OA\Property(property="config", ref="#/components/schemas/StoreConfig"),
+ * )
+ */
+class StoreSchema {}
+

--- a/app/OpenApi/Schemas/StoreUpdateRequestSchema.php
+++ b/app/OpenApi/Schemas/StoreUpdateRequestSchema.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="StoreUpdateRequest",
+ *     type="object",
+ *     @OA\Property(property="name", type="string", example="My Store Updated"),
+ *     @OA\Property(
+ *         property="config",
+ *         type="object",
+ *         @OA\Property(property="products", type="boolean", example=true),
+ *         @OA\Property(property="categories", type="boolean", example=true),
+ *         @OA\Property(property="cupons", type="boolean", example=false),
+ *         @OA\Property(property="gifcards", type="boolean", example=false),
+ *         @OA\Property(property="wishlist", type="boolean", example=false),
+ *         @OA\Property(property="reviews", type="boolean", example=false),
+ *         @OA\Property(
+ *             property="notifications",
+ *             type="object",
+ *             @OA\Property(property="emails", type="boolean", example=true),
+ *             @OA\Property(property="telegram", type="boolean", example=false)
+ *         )
+ *     )
+ * )
+ */
+class StoreUpdateRequestSchema {}
+

--- a/app/OpenApi/Schemas/TenantHeader.php
+++ b/app/OpenApi/Schemas/TenantHeader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Parameter(
+    parameter: "X-Store-Id",
+    name: "X-Store-Id",
+    description: "UUID de la tienda (tenant). Alternativamente puede usarse 'Store-Id'",
+    in: "header",
+    required: true,
+    schema: new OA\Schema(type: "string", format: "uuid", example: "b3b8c7e2-1c2d-4e5f-8a6b-123456789abc")
+)]
+class TenantHeader {}

--- a/app/Services/CurrentStore.php
+++ b/app/Services/CurrentStore.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Store;
+
+class CurrentStore
+{
+    protected static ?Store $store = null;
+
+    public static function set(?Store $store): void
+    {
+        self::$store = $store;
+    }
+
+    public static function get(): ?Store
+    {
+        return self::$store;
+    }
+
+    public static function id(): ?string
+    {
+        return self::$store?->id;
+    }
+
+    public static function has(): bool
+    {
+        return self::$store !== null;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,6 +20,8 @@ return Application::configure(basePath: dirname(__DIR__))
 
         // API middleware group
         $middleware->api([
+            \App\Http\Middleware\ResolveStore::class,
+            \App\Http\Middleware\RequireStore::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ]);
@@ -31,6 +33,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'customer.only' => \App\Http\Middleware\CustomerOnly::class,
             'api.key' => \App\Http\Middleware\ValidateApiKey::class,
             'role' => \App\Http\Middleware\CheckRole::class,
+            'tenant' => \App\Http\Middleware\ResolveStore::class,
+            'tenant.required' => \App\Http\Middleware\RequireStore::class,
         ]);
 
         // Configure CORS

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -156,6 +156,12 @@ return [
                     'name' => 'Authorization',
                     'in' => 'header',
                 ],
+                'tenant' => [
+                    'type' => 'apiKey',
+                    'description' => 'Tenant Store header. Use X-Store-Id with a UUID of the store (also accepts Store-Id).',
+                    'name' => 'X-Store-Id',
+                    'in' => 'header',
+                ],
             ],
             'security' => [
                 [

--- a/database/migrations/2025_08_04_140659_add_store_table.php
+++ b/database/migrations/2025_08_04_140659_add_store_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('store', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('store');
+        Schema::dropIfExists('store_configs');
+    }
+};

--- a/database/migrations/2025_08_04_150000_create_store_configs_table.php
+++ b/database/migrations/2025_08_04_150000_create_store_configs_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('store_configs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('store_id');
+            $table->boolean('products')->default(true);
+            $table->boolean('categories')->default(true);
+            $table->boolean('cupons')->default(false);
+            $table->boolean('gifcards')->default(false);
+            $table->boolean('wishlist')->default(false);
+            $table->boolean('reviews')->default(false);
+            $table->boolean('notifications_emails')->default(true);
+            $table->boolean('notifications_telegram')->default(false);
+            $table->timestamps();
+
+            $table->foreign('store_id')->references('id')->on('store')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('store_configs');
+    }
+};
+

--- a/database/migrations/2025_08_07_120000_add_store_relations_to_core_tables.php
+++ b/database/migrations/2025_08_07_120000_add_store_relations_to_core_tables.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Asegurar soft deletes en la tabla store
+        Schema::table('store', function (Blueprint $table) {
+            if (!Schema::hasColumn('store', 'deleted_at')) {
+                $table->softDeletes();
+            }
+        });
+
+        // Users -> store_id (nullable, set null on delete)
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'store_id')) {
+                $table->uuid('store_id')->nullable()->after('id');
+                $table->foreign('store_id')->references('id')->on('store')->nullOnDelete();
+                $table->index('store_id');
+            }
+        });
+
+        // Categories -> store_id
+        Schema::table('categories', function (Blueprint $table) {
+            if (!Schema::hasColumn('categories', 'store_id')) {
+                $table->uuid('store_id')->nullable()->after('id');
+                $table->foreign('store_id')->references('id')->on('store')->nullOnDelete();
+                $table->index('store_id');
+            }
+        });
+
+        // Products -> store_id
+        Schema::table('products', function (Blueprint $table) {
+            if (!Schema::hasColumn('products', 'store_id')) {
+                $table->uuid('store_id')->nullable()->after('id');
+                $table->foreign('store_id')->references('id')->on('store')->nullOnDelete();
+                $table->index('store_id');
+            }
+        });
+
+        // Carts -> store_id (cada carrito pertenece a una tienda)
+        Schema::table('carts', function (Blueprint $table) {
+            if (!Schema::hasColumn('carts', 'store_id')) {
+                $table->uuid('store_id')->nullable()->after('id');
+                $table->foreign('store_id')->references('id')->on('store')->nullOnDelete();
+                $table->index('store_id');
+            }
+        });
+
+        // Orders -> store_id
+        Schema::table('orders', function (Blueprint $table) {
+            if (!Schema::hasColumn('orders', 'store_id')) {
+                $table->uuid('store_id')->nullable()->after('id');
+                $table->foreign('store_id')->references('id')->on('store')->nullOnDelete();
+                $table->index('store_id');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Orders: quitar store_id
+        Schema::table('orders', function (Blueprint $table) {
+            try {
+                $table->dropForeign(['store_id']);
+            } catch (\Throwable $e) {
+            }
+            if (Schema::hasColumn('orders', 'store_id')) {
+                $table->dropColumn('store_id');
+            }
+        });
+
+        // Carts: quitar store_id
+        Schema::table('carts', function (Blueprint $table) {
+            try {
+                $table->dropForeign(['store_id']);
+            } catch (\Throwable $e) {
+            }
+            if (Schema::hasColumn('carts', 'store_id')) {
+                $table->dropColumn('store_id');
+            }
+        });
+
+        // Products: quitar store_id
+        Schema::table('products', function (Blueprint $table) {
+            try {
+                $table->dropForeign(['store_id']);
+            } catch (\Throwable $e) {
+            }
+            if (Schema::hasColumn('products', 'store_id')) {
+                $table->dropColumn('store_id');
+            }
+        });
+
+        // Categories: quitar store_id
+        Schema::table('categories', function (Blueprint $table) {
+            try {
+                $table->dropForeign(['store_id']);
+            } catch (\Throwable $e) {
+            }
+            if (Schema::hasColumn('categories', 'store_id')) {
+                $table->dropColumn('store_id');
+            }
+        });
+
+        // Users: quitar store_id
+        Schema::table('users', function (Blueprint $table) {
+            try {
+                $table->dropForeign(['store_id']);
+            } catch (\Throwable $e) {
+            }
+            if (Schema::hasColumn('users', 'store_id')) {
+                $table->dropColumn('store_id');
+            }
+        });
+
+        // Store: quitar soft deletes si lo agregamos
+        Schema::table('store', function (Blueprint $table) {
+            if (Schema::hasColumn('store', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,25 +32,14 @@ Route::get('/health', function () {
 // API Version 1 Routes
 Route::prefix('v1')->name('api.v1.')->group(function () {
 
-    // Public configuration endpoint
-    Route::get('/config', function () {
-        return response()->json([
-            'success' => true,
-            'data' => [
-                'app_name' => config('app.name'),
-                'modules' => [
-                    'coupons' => config('modules.coupons', false),
-                    'product_variants' => config('modules.product_variants', true),
-                    'wishlist' => config('modules.wishlist', false),
-                    'reviews' => config('modules.reviews', false),
-                ],
-                'features' => [
-                    'multi_payment_methods' => config('modules.multi_payment_methods', true),
-                    'notifications' => config('modules.notifications', [])
-                ]
-            ]
-        ]);
-    })->name('config');
+    // Excepción: rutas de store NO requieren tenant (se usa para crear/gestionar tiendas)
+    Route::prefix("store")->name("store.")->withoutMiddleware([\App\Http\Middleware\RequireStore::class])->group(function () {
+        Route::get('/', [\App\Http\Controllers\Api\V1\StoreController::class, 'index'])->name('index');
+        Route::post('/', [\App\Http\Controllers\Api\V1\StoreController::class, 'store'])->name('store');
+        Route::get('/{id}', [\App\Http\Controllers\Api\V1\StoreController::class, 'show'])->name('show');
+        Route::put('/{id}', [\App\Http\Controllers\Api\V1\StoreController::class, 'update'])->name('update');
+        Route::delete('/{id}', [\App\Http\Controllers\Api\V1\StoreController::class, 'destroy'])->name('destroy');
+    });
 
     // Authentication routes (no authentication required)
     Route::prefix('auth')->name('auth.')->group(function () {


### PR DESCRIPTION
- Added Store and StoreConfig models with relationships.
- Created StoreConfigResource and StoreResource for API responses.
- Introduced BelongsToStore trait for automatic store association.
- Updated existing models (Cart, Category, Order, Product, User) to support store relationships.
- Added middleware for resolving and requiring store context in requests.
- Created OpenAPI documentation for store-related endpoints and schemas.
- Implemented database migrations for store and store_configs tables.
- Refactored API routes to accommodate store management.